### PR TITLE
Update ExtendedTabbedPageRenderer.cs

### DIFF
--- a/CustomTabbedPage.Android/ExtendedTabbedPageRenderer.cs
+++ b/CustomTabbedPage.Android/ExtendedTabbedPageRenderer.cs
@@ -190,7 +190,7 @@ namespace CustomTabbedPage.Droid
                     var item = menuView.GetChildAt(i) as BottomNavigationItemView;
                     if (item == null)
                         continue;
-                    item.SetShiftingMode(enableItemShiftMode);
+                    item.SetShifting(enableItemShiftMode);
                     item.SetChecked(item.ItemData.IsChecked);
                 }
                 menuView.UpdateMenuView();


### PR DESCRIPTION
I guess the platform method has changed. This (item.SetShifting(enableItemShiftMode); was what removed the error in my case.
 item.SetShiftingMode(enableItemShiftMode); gave me error.